### PR TITLE
Fix syntax highlighting

### DIFF
--- a/Hare.sublime-syntax
+++ b/Hare.sublime-syntax
@@ -33,7 +33,7 @@ contexts:
 
   keywords:
     # Keywords are if, else for and while.
-    # Note that blackslashes don't need to be escaped within single quoted
+    # Note that backslashes don't need to be escaped within single quoted
     # strings in YAML. When using single quoted strings, only single quotes
     # need to be escaped: this is done by using two single quotes next to each
     # other.
@@ -47,11 +47,9 @@ contexts:
       push:
         - match: ' \b[a-zA-Z]*\b'
           scope: meta.preprocessor.hare
-          #pop: true
-          push:
-            - match: ';'
-              scope: keyword.control.endident.hare
-              pop: 2
+        - match: ';'
+          scope: keyword.control.endident.hare
+          pop: true
 
 
   numbers:
@@ -61,7 +59,7 @@ contexts:
     # float second
     - match: '\b(\+|-)?[0-9]((e|E)(\+|-)?[0-9]+)?(f32|f64)?\b'
       scope: constant.numeric.hare
-    #decimal
+    # decimal
     - match: '\b(-)?[0-9.]+(i64|i32|i16|i8|u64|u32|u16|u8|i|u|z)?\b'
       scope: constant.numeric.hare
     # hex digits

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 Syntax highlighting for [Hare language](https://harelang.org/)
 
-Whats in:
+What's in:
+
  * all keywords
  * strings
  * numericals
 
-Todo:
+To do:
+
  * add autocompletion for standard libraries


### PR DESCRIPTION
I just found this syntax highlighting repository for Hare. Thanks for your great work!

I have tested it using [bat](https://github.com/sharkdp/bat) and it looks broken:

![2023-05-24 20 20 00 719x599 Region](https://github.com/artursartamonovs/hare-highlight/assets/13970628/7695dd66-816b-4b04-8daa-cf9a1b546a61)

This little pull request fixes it:

![2023-05-24 20 20 37 711x593 Region](https://github.com/artursartamonovs/hare-highlight/assets/13970628/f532fa40-47fd-422a-9190-4d290b603011)

And it fixes some typos.