### PR TITLE
Fix/extend inside_string context

### DIFF
--- a/Hare.sublime-syntax
+++ b/Hare.sublime-syntax
@@ -85,8 +85,14 @@ contexts:
   inside_string:
     - meta_include_prototype: false
     - meta_scope: string.quoted.double.hare
-    - match: '\.'
+    - match: '\\.'
       scope: constant.character.escape.hare
+    - match: '{'
+      scope: constant.character.escape.hare
+      push:
+        - match: '.*?}'
+          scope: constant.character.escape.hare
+          pop: true
     - match: '"'
       scope: punctuation.definition.string.end.hare
       pop: true


### PR DESCRIPTION
Highlighting of escaped characters inside strings does not work as intended. Placeholders are not recognized at all.

Before (with PR #7 applied):

![2023-05-24 21 02 00 742x309 Region](https://github.com/artursartamonovs/hare-highlight/assets/13970628/565addf6-fad4-41cb-93b5-496c3b77b41e)

With this pull request applied as well:

![2023-05-24 21 01 35 747x318 Region](https://github.com/artursartamonovs/hare-highlight/assets/13970628/719076b1-0cb7-4fac-9e45-904226e9467b)