### PR TITLE
Improve string matching and add comment toggling

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.hare</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>// </string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/Hare.sublime-syntax
+++ b/Hare.sublime-syntax
@@ -26,7 +26,9 @@ contexts:
     - include: keywords
     - include: use_keyword
     - include: numbers
+    - include: characters
     - include: strings
+    - include: strings_2
     - include: single_quote_string
     - include: operators
 
@@ -37,8 +39,10 @@ contexts:
     # strings in YAML. When using single quoted strings, only single quotes
     # need to be escaped: this is done by using two single quotes next to each
     # other.
-    - match: '\b(abort|alloc|append|as|assert|bool|break|case|char|const|continue|def|defer|delete|else|enum|export|f32|f64|false|fn|for|free|i16|i32|i64|i8|if|int|is|len|let|match|null|nullable|offset|return|rune|size|static|str|struct|switch|true|type|u16|u32|u64|u8|uint|uintptr|union|void|_|yield)\b'
+    - match: '\b(abort|align|alloc|append|as|assert|bool|break|case|char|const|continue|def|defer|delete|else|enum|export|f32|f64|false|fn|for|free|i16|i32|i64|i8|if|int|is|len|let|match|never|null|nullable|offset|return|rune|size|static|str|struct|switch|true|type|u16|u32|u64|u8|uint|uintptr|union|vaarg|vaend|valist|vastart|void|_|yield)\b'
       scope: keyword.control.hare
+    - match: '(@[a-z]+)'
+      scope: keyword.attribute.hare
 
 
   use_keyword:
@@ -72,40 +76,42 @@ contexts:
     - match: '\b(0[o])({{oct_digit}}*)(i64|i32|i16|i8|u64|u32|u16|u8|i|u|z)?\b'
       scope: constant.numeric.hare
 
+  characters:
+    - match: '''([^''\\]|\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))'''
+      scope: string.quoted.single.hare
 
   strings:
     # Strings begin and end with quotes, and use backslashes as an escape
     # character.
     - match: '"'
       scope: punctuation.definition.string.begin.hare
-      push: inside_string
-
-  inside_string:
-    - meta_include_prototype: false
-    - meta_scope: string.quoted.double.hare
-    - match: '\\.'
-      scope: constant.character.escape.hare
-    - match: '{'
-      scope: constant.character.escape.hare
       push:
-        - match: '.*?}'
-          scope: constant.character.escape.hare
+        - meta_scope: string.quoted.double.hare
+          meta_include_prototype: false
+        - match: '"'
+          scope: punctuation.definition.string.end.hare
           pop: true
-    - match: '"'
-      scope: punctuation.definition.string.end.hare
-      pop: true
+        - match: \\(0|a|b|f|n|r|t|v|\\|\'|\"|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})
+          scope: constant.character.escape.hare
+        - match: '\{\{|\}\}'
+          scope: constant.character.format.hare
+        - match: '{([0-9]*(:([0\-\+\=\_\ ]*(\.)?[0-9]*(x|X|o|b)?(\.[0-9]*)?|[efgFs\.UES2]*))?|[0-9]*%[0-9]*)}'
+          scope: constant.character.format.hare
 
-  single_quote_string:
-    # Strings begin and end with quotes, and use backslashes as an escape
-    # character.
-    - match: "'"
+  strings_2:
+    - match: "`"
       scope: punctuation.definition.string.begin.hare
-      push: inside_single_quote_string
+      push:
+        - meta_scope: string.quoted.double.hare
+          meta_include_prototype: false
+        - match: '`'
+          scope: punctuation.definition.string.end.hare
+          pop: true
+        - match: '\{\{|\}\}'
+          scope: constant.character.format.hare
+        - match: '{([0-9]*(:([0\-\+\=\_\ ]*(\.)?[0-9]*(x|X|o|b)?(\.[0-9]*)?|[efgFs\.UES2]*))?|[0-9]*%[0-9]*)}'
+          scope: constant.character.format.hare
 
-  inside_single_quote_string:
-    - match: "'"
-      scope: punctuation.definition.string.end.hare
-      pop: true
 
   comments:
     # Comments begin with a '//' and finish at the end of the line.
@@ -127,3 +133,5 @@ contexts:
       scope: keyword.operator.arithmetic.hare
     - match: <|>|<\=|>\=|\=\=|\!\=
       scope: keyword.operator.comparison.c
+    - match: \=>|::|:|\?|!|\|
+      scope: keyword.operator.misc.hare

--- a/Hare.sublime-syntax
+++ b/Hare.sublime-syntax
@@ -133,5 +133,5 @@ contexts:
       scope: keyword.operator.arithmetic.hare
     - match: <|>|<\=|>\=|\=\=|\!\=
       scope: keyword.operator.comparison.c
-    - match: \=>|::|:|\?|!|\|
+    - match: \=>|::|:|\?|!|\||\.\.\.|\.\.
       scope: keyword.operator.misc.hare


### PR DESCRIPTION
## An Introductory Note
Hello friend,

I saw that you had published this plugin to the Sublime package repository, and I wanted to improve it with some of the changes I had made when updating [a different Sublime plugin for Hare](https://github.com/alecGraves/hare-sublime-syntax). Notably, this change adds the ability to toggle comments via hot-key (default `ctrl` + `/`) and offers improved validity checking of strings and character literals. It also adds some of my previous work to highlight valid `fmt` escapes in text.

Please consider merging these changes into your repository so that others may have a truly sublime first experience with Hare!

My changes are released under [the Unlicense](https://unlicense.org/), so please incorporate them as you see fit!

Thank you,

~Alec

## Delightful Imagery

### Backtick Strings ``` ` ```
![hare_working_4](https://github.com/artursartamonovs/hare-highlight/assets/15484056/0a1cedaa-520e-4770-9732-05a7e10650a7)

### Format Strings `fmt/+test.ha`
![hare_working_3](https://github.com/artursartamonovs/hare-highlight/assets/15484056/5cffb6e5-02ce-42d5-ae4f-d5ef982af0d1)

### Curly Braces
![image](https://github.com/artursartamonovs/hare-highlight/assets/15484056/477b60aa-d7a5-4f4d-99ce-84d409caae82)

(some before pictures of curly braces:)
![hare_braces_fail](https://github.com/artursartamonovs/hare-highlight/assets/15484056/59a99186-96d1-4203-8de3-cdab2fcb85b5)
